### PR TITLE
Add CI and coverage testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ setup.files
 # cython stuff
 *.c
 *.so
+
+# coverage results
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+
+matrix:
+  include:
+    - python: "2.7"
+    - python: "3.3"
+    - python: "3.4"
+    - python: "3.5"
+    - python: "3.6"
+    - python: "nightly"
+  allow_failures:
+    - python: "nightly"
+
+install:
+  - pip install -r requirements.txt
+  - pip install coverage coveralls # for CI
+
+script:
+  - make compile
+  - coverage run --source=fastmat util/bee.py test -vi
+
+after_success: >
+  if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+    coveralls
+  fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+cython
+numpy
+scipy
+matplotlib


### PR DESCRIPTION
Servus!

This PR adds continuous integration (testing against Python 2.7, 3.3, 3.4, 3.5, 3.6 on Linux) and coverage reporting (to Coveralls).

You can see how it looks [here](https://travis-ci.org/mp4096/fastmat). It's still running, so probably I'll have to update the config before merging.

Cheers! :beers: