### PR TITLE
Add herm Option in CG and fix Bug in Test

### DIFF
--- a/fastmat/algs/CG.pxd
+++ b/fastmat/algs/CG.pxd
@@ -18,4 +18,4 @@
 cimport numpy as np
 from ..Matrix cimport Matrix
 
-cpdef np.ndarray CG(Matrix, np.ndarray, float eps=?)
+cpdef np.ndarray CG(Matrix, np.ndarray, int herm=?, float eps=?)

--- a/fastmat/algs/CG.pxd
+++ b/fastmat/algs/CG.pxd
@@ -18,4 +18,4 @@
 cimport numpy as np
 from ..Matrix cimport Matrix
 
-cpdef np.ndarray CG(Matrix, np.ndarray, int herm=?, float eps=?)
+cpdef np.ndarray CG(Matrix, np.ndarray, bint hermitian=?, float errorTol=?)

--- a/fastmat/algs/CG.pyx
+++ b/fastmat/algs/CG.pyx
@@ -32,6 +32,7 @@ from ..Matrix cimport Matrix
 cpdef np.ndarray CG(
     Matrix fmatA,
     np.ndarray arrB,
+    int herm=0,
     float eps=0
 ):
     r"""Conjugate Gradient Method
@@ -52,7 +53,8 @@ cpdef np.ndarray CG(
     instead. In this case it should be noted, that the condition number of
     :math:`A^\mathrm{H} \cdot A` might be a lot larger than the one of
     :math:`A` an thus we might run into stability problems for large and already
-    ill-conditioned systems.
+    ill-conditioned systems. So for Hermitian :math:`A` it should be called
+    with parameter `herm=1`
 
     This algorithm was originally described in [3]_ and is applicable here,
     because it only uses the backward and forward projection of a matrix.
@@ -68,7 +70,7 @@ cpdef np.ndarray CG(
     >>> # define the right hand side
     >>> b = npr.randn(2 ** n)
     >>> # solve the system
-    >>> y = fma.CG(H, b)
+    >>> y = fma.CG(H, b, herm=1)
     >>> # check if solution is correct
     >>> print(np.allclose(b, H.forward(y)))
 
@@ -82,6 +84,8 @@ cpdef np.ndarray CG(
         the system matrix
     arrB : np.ndarray
         the right hand side of the system of equations
+    herm : bool, optional
+        flag whether the system matrix is Hermitian or not
     eps : float, optional
         threshold for stopping the iteration; default is 0
 
@@ -103,14 +107,14 @@ cpdef np.ndarray CG(
 
     # dispatch specialization of core routine according tOptor
     if typeOut == np.float32:
-        return _CGcore[np.float32_t](fmatA, arrIn, npTypeOut, 0., eps)
+        return _CGcore[np.float32_t](fmatA, arrIn, npTypeOut, 0., herm, eps)
     elif typeOut == np.float64:
-        return _CGcore[np.float64_t](fmatA, arrIn, npTypeOut, 0., eps)
+        return _CGcore[np.float64_t](fmatA, arrIn, npTypeOut, 0., herm, eps)
     elif typeOut == np.complex64:
-        return _CGcore[np.complex64_t](fmatA, arrIn, npTypeOut, 0., eps)
+        return _CGcore[np.complex64_t](fmatA, arrIn, npTypeOut, 0., herm, eps)
     elif typeOut == np.complex128:
         return \
-            _CGcore[np.complex128_t](fmatA, arrIn, npTypeOut, 0., eps)
+            _CGcore[np.complex128_t](fmatA, arrIn, npTypeOut, 0., herm, eps)
     else:
         raise NotImplementedError("Output type %d not supported." % (typeOut))
 
@@ -120,6 +124,7 @@ cdef np.ndarray _CGcore(
     np.ndarray arrB,
     nptype npTypeOut,
     TYPE_FLOAT typeTag,
+    int herm,
     float eps
 ):
 
@@ -138,6 +143,7 @@ cdef np.ndarray _CGcore(
     # numAlpha     - optimal step with
     # numRNormNew  - new residual norm
     # numRNormOld  - old residual norm
+    # herm         - flag whether system is Hermitian
     # eps          - stopping condition to the projected residual
 
     # NOTE: typeTag is used for telling the compiler the used specialization
@@ -158,8 +164,13 @@ cdef np.ndarray _CGcore(
 
     # change right hand side of equation system according to symmetrization
     # force to be F-contiguous and of consistent data type (no ints here)
-    cdef np.ndarray arrR = _arrForceTypeAlignment(
-        fmatA.backward(arrB), npTypeOut, np.NPY_FORCECAST)
+    cdef np.ndarray arrR
+    if herm == 0:
+        arrR = _arrForceTypeAlignment(
+            fmatA.backward(arrB), npTypeOut, np.NPY_FORCECAST)
+    else:
+        arrR = _arrForceTypeAlignment(arrB, npTypeOut, np.NPY_FORCECAST)
+
     cdef TYPE_FLOAT * pArrR = <TYPE_FLOAT * > arrR.data
     cdef TYPE_FLOAT * vecR
     arrOut = _arrZero(2, fmatA.numM, M, npTypeOut)
@@ -185,7 +196,11 @@ cdef np.ndarray _CGcore(
 
         # iterate until stopping criterion is met
         while numRNormOld > eps:
-            arrQ = fmatA.gram.forward(arrP)
+            if herm == 0:
+                arrQ = fmatA.gram.forward(arrP)
+            else:
+                arrQ = fmatA.forward(arrP)
+
             vecQ = <TYPE_FLOAT * > arrQ.data
 
             # calculate next optimal step width according to
@@ -240,7 +255,7 @@ class CGinspect(Algorithm):
         def testCG(test):
 
             # prepare vectors
-            test[TEST.RESULT_REF]    = arrTestDist((test[TEST.NUM_M],
+            test[TEST.RESULT_REF]    = arrTestDist((test[TEST.NUM_N],
                                                     test[TEST.DATACOLS]),
                                                    dtype=test[TEST.DATATYPE])
             test[TEST.RESULT_INPUT]  = (test[TEST.INSTANCE] *
@@ -251,7 +266,7 @@ class CGinspect(Algorithm):
         return {
             TEST.ALGORITHM: {
                 TEST.NUM_N      : 27,
-                TEST.NUM_M      : TEST.NUM_N,
+                TEST.NUM_M      : 3,
 
                 'typeA'         : TEST.Permutation(TEST.ALLTYPES),
                 'arrA'          : TEST.ArrayGenerator({


### PR DESCRIPTION
1. The CG Algorithm gets a herm option which yields a
speedup by factor of two.

2. Fix Bug in Testgeneration, which has set wrong sizes,
which lead to test crashes