### PR TITLE
Linear operator

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,7 @@
    submod
    bee
    tutorials
+   scipy
 
 Welcome to fastmat's documentation!
 ===================================
@@ -36,10 +37,11 @@ Table of Contents
 * :ref:`modindex`
 * :ref:`search`
 * :ref:`submod`
+* :ref:`scipy`
 * :ref:`tutorials`
-
  * :ref:`Tutorial for Scientific Users`
  * :ref:`Tutorial for Scientific Programmers`
+
 
 .. automodule:: fastmat
 
@@ -48,7 +50,7 @@ Public Appearances
 
 Sometimes we also get out in the wild and present the package. The talks we held can be found below.
 
-    - EurcScipy 2017 Erlangen: `PDF <https://github.com/EMS-TU-Ilmenau/fastmat/releases/download/0.1/082017euroscipy.pdf>`_, `Youtube <https://www.youtube.com/watch?v=dq5bLgLGae8>`_
+    - EuroScipy 2017 Erlangen: `PDF <https://github.com/EMS-TU-Ilmenau/fastmat/releases/download/0.1/082017euroscipy.pdf>`_, `Youtube <https://www.youtube.com/watch?v=dq5bLgLGae8>`_
 
 
 Contributions

--- a/doc/scipy.rst
+++ b/doc/scipy.rst
@@ -1,0 +1,64 @@
+..  Copyright 2016 Sebastian Semper, Christoph Wagner
+        https://www.tu-ilmenau.de/it-ems/
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+.. _scipy:
+
+SciPy Interface
+===============
+
+Table of Contents
+-----------------
+
+ * `Motivation`_
+ * `Examples`_
+
+.. _`Motivation`:
+
+Motivation for a SciPy Interface
+--------------------------------
+
+SciPy offers a large zoo of algorithms which exploit the possibility to pass a so called LinearOperator, which only provides methods for forward and backward transforms together with some simple properties like a datatype and shape parameters. This is exactly what we can provide for a specific instance of a fastmat Matrix. To this end, each fastmat Matrix has the (read only) property scipyLinearOperator, which provides a SciPy Linear operator realizing the transform specified by the fastmat object.
+
+This allows to combine fastmat and SciPy in the most efficient manner possible. Here, fastmat provides the simple and efficient description of a huge variety of linear operators, which can then be used neatly and trouble free in SciPy.
+
+
+.. _`Examples`:
+
+Examples
+--------
+
+Solve a system of linear equations with preconditioning, where the preconditioner can also be provided as a LinearOperator.
+
+>>> import fastmat as fm
+>>> import numpy as np
+>>> from scipy.sparse.linalg import cgs
+>>>
+>>> # diagonal matrix with no zeros
+>>> d = np.random.uniform(1, 20, 2**numO)
+>>>
+>>> # fastmat object
+>>> H = fm.Diag(d)
+>>>
+>>> # use the new property to generate a scipy linear operator
+>>> Hs = H1.scipyLinearOperator
+>>>
+>>> # also generate a Preconditioning linear operator,
+>>> # which in this case is the exact inverse
+>>> Ms = fm.Diag(1.0 / d).scipyLinearOperator
+>>>
+>>> # get a baseline
+>>> y = np.linalg.solve(H1.array, x)
+>>> cgs(Hs, x, tol=1e-10)
+>>> cgs(Hs, x, tol=1e-10, M=Ms)

--- a/fastmat/Matrix.pxd
+++ b/fastmat/Matrix.pxd
@@ -69,6 +69,7 @@ cdef class Matrix:
     cdef public Matrix      _normalized          # cache for normalized matrix
     cdef public object      _largestEV           # cache for largestEV
     cdef public object      _largestSV           # cache for largestSV
+    cdef public object      _scipyLinearOperator # interface to scipy
     cdef public Matrix      _T                   # cache for transpose matrix
     cdef public Matrix      _H                   # cache for adjunct matrix
     cdef public Matrix      _conj                # cache for conjugate matrix
@@ -101,6 +102,7 @@ cdef class Matrix:
     cpdef object _getItem(self, intsize, intsize)
     cpdef object _getLargestEV(self, intsize, float, float, bint)
     cpdef object _getLargestSV(self, intsize, float, float, bint)
+    cpdef object _getScipyLinearOperator(self)
     cpdef Matrix _getGram(self)
     cpdef Matrix _getNormalized(self)
     cpdef Matrix _getT(self)

--- a/fastmat/Matrix.pyx
+++ b/fastmat/Matrix.pyx
@@ -225,29 +225,6 @@ cdef class Matrix(object):
     **Description:**
     The baseclass of all matrix classes in fastmat. It also serves as wrapper
     around the standard Numpy Array [1]_.
-
-    **Performance Benchmarks**
-
-    .. figure:: _static/bench/Matrix.overhead.png
-        :width: 50%
-
-        Overhead Benchmarking of this class
-
-    .. figure:: _static/bench/Matrix.dtypes.png
-        :width: 50%
-
-        Dtypes Benchmarking of this class
-
-    .. figure:: _static/bench/Matrix.forward.png
-        :width: 50%
-
-        Forward Multiplication numbers
-
-    .. todo::
-        - extend docu
-        - add caches for cols / rows
-        - implement generation of normalized matrix of general matrices
-
     """
 
     ############################################## basic class properties
@@ -770,7 +747,8 @@ cdef class Matrix(object):
             shape=(self.numN, self.numM),
             matvec=self.forward,
             rmatvec=self.backward,
-            matmat=self.forward
+            matmat=self.forward,
+            dtype=np.promote_types(np.int8, self.dtype)
         )
 
 

--- a/fastmat/Matrix.pyx
+++ b/fastmat/Matrix.pyx
@@ -743,6 +743,38 @@ cdef class Matrix(object):
         # did not converge - return NaN
         return (np.sqrt(normNew) if alwaysReturn else np.float64(np.NaN))
 
+
+    property scipyLinearOperator:
+        """Return a Representation as scipy's linear Operator
+
+        This property allows to make use of all the powerfull algorithms
+        provided by scipy, that allow passing a linear operator to
+        them, like optimization routines, system solvers or decomposition
+        algorithms.
+
+        *(read-only)*
+        """
+        def __get__(self):
+            if self._scipyLinearOperator is None:
+                return self._getScipyLinearOperator()
+            else:
+                self._scipyLinearOperator
+
+    cpdef object _getScipyLinearOperator(self):
+        from scipy.sparse.linalg import LinearOperator
+        result = LinearOperator(
+            shape=(self.numN, self.numM),
+            matvec=self.forward,
+            rmatvec=self.backward,
+            matmat=self.forward
+        )
+
+        self._scipyLinearOperator = result
+
+        return result
+
+
+
     ############################################## generic algebraic properties
     property gram:
         r"""Return the gram matrix for this fastmat class

--- a/fastmat/Matrix.pyx
+++ b/fastmat/Matrix.pyx
@@ -756,22 +756,22 @@ cdef class Matrix(object):
         """
         def __get__(self):
             if self._scipyLinearOperator is None:
-                return self._getScipyLinearOperator()
+                return self.getScipyLinearOperator()
             else:
-                self._scipyLinearOperator
+                return self._scipyLinearOperator
+
+    def getScipyLinearOperator(self):
+        self._scipyLinearOperator = self._getScipyLinearOperator()
+        return self._scipyLinearOperator
 
     cpdef object _getScipyLinearOperator(self):
         from scipy.sparse.linalg import LinearOperator
-        result = LinearOperator(
+        return LinearOperator(
             shape=(self.numN, self.numM),
             matvec=self.forward,
             rmatvec=self.backward,
             matmat=self.forward
         )
-
-        self._scipyLinearOperator = result
-
-        return result
 
 
 

--- a/fastmat/inspect/benchmark.py
+++ b/fastmat/inspect/benchmark.py
@@ -76,29 +76,29 @@ class BENCH(NAME):
 
 ################################################## weightedPercentile()
 def weightedPercentile(data, **options):
-    """
-    O(nlgn) implementation for weighted_percentile, with linear interpolation
-    #between weights.
-
-    date:       Aug 25 '16 @ 13:37
-    user:       nayyrv [Aug 16 '15 @ 10:52]
-    source:     www.stackoverflow.com/questions/
-                    21844024/weighted-percentile-using-numpy
-    ``  This is my function, it give identical behaviour to `np.percentile(
-        np.repeat(data, weights), percentile)` With less memory overhead,
-        np.percentile is an O(n) implementation so it's potentially faster for
-        small weights. It has all the edge cases sorted out - it's an exace
-        solution. The interpolation answers above assume linear, when it's a
-        step for most of he case, except when the weight is 1.
-
-        Say we have data [1,2,3] with weights [3, 11, 7] and I want the
-        25% percentile. My ecdf is going to be [3, 10, 21] and I'm looking for
-        the 5th value. The interpolation will see [3, 1] and [10, 2] as the
-        matches and interpolate gving 1.28 despite being entirely in the
-        2nd bin with a value of 2.
-    ``
-
-    """
+    # """
+    # O(nlgn) implementation for weighted_percentile, with linear interpolation
+    # #between weights.
+    #
+    # date:       Aug 25 '16 @ 13:37
+    # user:       nayyrv [Aug 16 '15 @ 10:52]
+    # source:     www.stackoverflow.com/questions/
+    #                 21844024/weighted-percentile-using-numpy
+    # ``  This is my function, it give identical behaviour to `np.percentile(
+    #     np.repeat(data, weights), percentile)` With less memory overhead,
+    #     np.percentile is an O(n) implementation so it's potentially faster for
+    #     small weights. It has all the edge cases sorted out - it's an exace
+    #     solution. The interpolation answers above assume linear, when it's a
+    #     step for most of he case, except when the weight is 1.
+    #
+    #     Say we have data [1,2,3] with weights [3, 11, 7] and I want the
+    #     25% percentile. My ecdf is going to be [3, 10, 21] and I'm looking for
+    #     the 5th value. The interpolation will see [3, 1] and [10, 2] as the
+    #     matches and interpolate gving 1.28 despite being entirely in the
+    #     2nd bin with a value of 2.
+    # ``
+    #
+    # """
     # extract options
     percentile = np.array(options.get('percentile', [75, 25])) / 100.
     weights = options.get('weights', None)
@@ -181,10 +181,10 @@ def timeCall(call, *args, **options):
     specified by call(*args).
 
     Behaviour of the measurements can be adjusted with these options:
-      minMeasTime       - minimum total time the evaluation shall take
-      minRepetitions    - minimum number of calls needed for evaluation
-      minRuns           - minimum number of single measurements (of one or more
-                          repetitions each) required
+    minMeasTime       - minimum total time the evaluation shall take
+    minRepetitions    - minimum number of calls needed for evaluation
+    minRuns           - minimum number of single measurements (of one or more
+                      repetitions each) required
     '''
     stats=[]
 

--- a/fastmat/inspect/common.py
+++ b/fastmat/inspect/common.py
@@ -718,11 +718,11 @@ class NAME(object):
 class Worker(object):
     '''
     options - dictionary structure containing options for multiple targets.
-        {   'nameOfTarget': {'parameter': 123,
-                                'anotherParameter': 456
-         }, NAME.DEFAULTS:  {'parameter': default parameter unless overwritten
-                                          within the selected target
-         }}
+    {   'nameOfTarget': {'parameter': 123,
+    'anotherParameter': 456
+    }, NAME.DEFAULTS:  {'parameter': default parameter unless overwritten
+    within the selected target
+    }}
 
     results - output of each target's as specified in options
     '''


### PR DESCRIPTION
# Motivation

SciPy offers a large zoo of algorithms which exploit the possibility to pass a so called LinearOperator, which only provides methods for forward and backward transforms together with some simple properties like a datatype and shape parameters. This is exactly what we can provide for a specific instance of a fastmat Matrix. To this end, each fastmat Matrix has the (read only) property scipyLinearOperator, which provides a SciPy Linear operator realizing the transform specified by the fastmat object.

This allows to combine fastmat and SciPy in the most efficient manner possible. Here, fastmat provides the simple and efficient description of a huge variety of linear operators, which can then be used neatly and trouble free in SciPy.

# Examples
Solve a system of linear equations with preconditioning, where the preconditioner can also be provided as a LinearOperator. See the attached [file](https://github.com/EMS-TU-Ilmenau/fastmat/files/2366368/scipyLinearOperator.zip) for a comparison. The file also outlines how crappy our own conjugate gradient method actually is.

# Take Home Message
We should now mainly stick to defining the transforms and use the new SciPy interface if we want to run these algorithms, since these are very nicely tested and very performant.
