### PR TITLE
Reconfigure appveyor CI setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,7 @@ install:
 
 build_script:
   - pip install cibuildwheel==0.9.4 twine
-  - make compile
+  - python setup.py build_ext --inplace
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,7 +90,7 @@ install:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
   - "ECHO %CIBW_SKIP%"
   - "ECHO %CIBW_ENVIRONMENT%"
-  - "ECHO %PATH%
+  - "ECHO %PATH%"
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 branches:
   only:
     - stable
+    - cisetup
 
 environment:
   global:
@@ -73,6 +74,7 @@ install:
 
 build_script:
   - pip install cibuildwheel==0.9.4 twine
+  - make compile
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,47 +21,76 @@ environment:
     secure: s5rlS2aZ0pdnIhWQrN0B0LZO5FU6B7CIp1ON4wriejs=
 
   matrix:
-    - PYTHON: "C:\\Python27_64"
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+      CONDA_PY: "27"
+      CIBW_SKIP: 'cp[!2]?-* cp2[!7]-*'
+
+    - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "27"
       CIBW_SKIP: 'cp[!2]?-* cp2[!7]-*'
 
-    - PYTHON: "C:\\Python34_64"
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "32"
+      CONDA_PY: "34"
+      CIBW_SKIP: 'cp[!3]?-* cp3[!4]-*'
+
+    - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "64"
       CONDA_PY: "34"
       CIBW_SKIP: 'cp[!3]?-* cp3[!4]-*'
 
-    - PYTHON: "C:\\Python35_64"
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "32"
+      CONDA_PY: "35"
+      CIBW_SKIP: 'cp[!3]?-* cp3[!5]-*'
+
+    - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
       CONDA_PY: "35"
       CIBW_SKIP: 'cp[!3]?-* cp3[!5]-*'
 
-    - PYTHON: "C:\\Python36_64"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+      CONDA_PY: "36"
+      CIBW_SKIP: 'cp[!3]?-* cp3[!6]-*'
+
+    - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       CONDA_PY: "36"
       CIBW_SKIP: 'cp[!3]?-* cp3[!6]-*'
 
-    - PYTHON: "C:\\Python37_64"
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "32"
+      CONDA_PY: "37"
+      CIBW_SKIP: 'cp[!3]?-* cp3[!7]-*'
+
+     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "37"
       CIBW_SKIP: 'cp[!3]?-* cp3[!7]-*'
+
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
-
-init:
-  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
-  - "ECHO %CIBW_SKIP%"
-  - "ECHO %CIBW_ENVIRONMENT%"
-  - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""
 
 install:
   # Prepend chosen Python to the PATH of this build
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+  - "ECHO %CIBW_SKIP%"
+  - "ECHO %CIBW_ENVIRONMENT%"
+  - "ECHO %PATH%
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
@@ -74,7 +103,6 @@ install:
 
 build_script:
   - pip install cibuildwheel==0.9.4 twine
-  - python setup.py build_ext --inplace
   - pip install .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -109,7 +109,7 @@ build_script:
 test_script:
   - python bee.py test -v
   - cibuildwheel --output-dir wheelhouse
-  - twine upload "wheelhouse\\*.whl"
+  - twine upload "wheelhouse\\*.whl" & exit 0
 
 artifacts:
   - path: "wheelhouse\\*.whl"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,8 +102,9 @@ install:
      print(sys.platform, platform.machine(), struct.calcsize('P') * 8, )"
 
 build_script:
-  - pip install cibuildwheel==0.9.4 twine
-  - pip install .
+  - python -m pip install cibuildwheel==0.9.4 twine
+  - python setup.py build_ext --inplace
+  - python -m pip install .
 
 test_script:
   - python bee.py test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,7 @@ environment:
       CONDA_PY: "37"
       CIBW_SKIP: 'cp[!3]?-* cp3[!7]-*'
 
-     - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "37"


### PR DESCRIPTION
Due to build problems on Appveyor some settings needed to be adjusted. There might still be some trouble for some python 3.x-64 versions. However this could also be due to build articfacts and should be observed for future builds.