### PR TITLE
Add sanity check for numMaxSteps to algorithms

### DIFF
--- a/fastmat/algorithms/FISTA.py
+++ b/fastmat/algorithms/FISTA.py
@@ -129,13 +129,16 @@ class FISTA(Algorithm):
         #                     between data fidelity and sparsity
         #     numMaxSteps   - maximum number of steps to run
         #     numL          - step size during the conjugate gradient step
-        if arrB.ndim > 2:
+        if arrB.ndim > 2 or arrB.ndim < 1:
             raise ValueError("Only n x m arrays are supported for FISTA")
 
         if arrB.ndim == 1:
             self.arrB = arrB.reshape((-1, 1))
         else:
             self.arrB = arrB
+
+        if self.numMaxSteps <= 0:
+            raise ValueError("FISTA would like to do at least one step for you")
 
         # calculate the largest singular value to get the right step size
         self.numL = 1.0 / (self.fmatA.largestSingularValue ** 2)

--- a/fastmat/algorithms/ISTA.py
+++ b/fastmat/algorithms/ISTA.py
@@ -129,13 +129,16 @@ class ISTA(Algorithm):
         #                 between data fidelity and sparsity
         # numMaxSteps   - maximum number of steps to run
         # numL          - step size during the conjugate gradient step
-        if arrB.ndim > 2:
+        if arrB.ndim > 2 or arrB.ndim < 1:
             raise ValueError("Only n x m arrays are supported for ISTA")
 
         if arrB.ndim == 1:
             self.arrB = arrB.reshape((-1, 1))
         else:
             self.arrB = arrB
+
+        if self.numMaxSteps <= 0:
+            raise ValueError("ISTA would like to do at least one step for you")
 
         # calculate the largest singular value to get the right step size
         self.numL = 1.0 / (self.fmatA.largestSingularValue ** 2)

--- a/fastmat/algorithms/OMP.pyx
+++ b/fastmat/algorithms/OMP.pyx
@@ -132,13 +132,16 @@ cdef class OMP(Algorithm):
         #                       strides
         #
 
-        if arrB.ndim > 2:
+        if arrB.ndim > 2 or arrB.ndim < 1:
             raise ValueError("Only n x m arrays are supported for OMP")
 
         if arrB.ndim == 1:
             self.arrB = arrB.reshape((-1, 1))
         else:
             self.arrB = arrB
+
+        if self.numMaxSteps <= 0:
+            raise ValueError("OMP would wish to do at least one step for you")
 
         # get the number of vectors to operate on
         self.numN, self.numM, self.numL = \

--- a/fastmat/algorithms/STELA.py
+++ b/fastmat/algorithms/STELA.py
@@ -126,13 +126,16 @@ class STELA(Algorithm):
         return np.multiply((arrM / (arrM + numAlpha)), arrX)
 
     def _process(self, arrB):
-        if arrB.ndim > 2:
+        if arrB.ndim > 2 or arrB.ndim < 1:
             raise ValueError("Only n x m arrays are supported for STELA")
 
         if arrB.ndim == 1:
             self.arrB = arrB.reshape((-1, 1))
         else:
             self.arrB = arrB
+
+        if self.numMaxSteps <= 0:
+            raise ValueError("STELA would like to do at least one step for you")
 
         dtypeType = np.promote_types(np.float32, self.arrB.dtype)
 


### PR DESCRIPTION
Previously, people have been wondering why our algorithms are so fast when you forget to specify numMaxSteps