### PR TITLE
Add appropriate handling of compiler options for Apple Silicon Arm to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -259,7 +259,7 @@ if __name__ == '__main__':
     f.close()
 
     # Build for Apple Silicon
-    if platform.system() == "Darwin" and platform.machine() == "arm64": 
+    if platform.system() == "Darwin" and platform.machine() == "arm64":
         marchFlag = "-mcpu=apple-m1"
         mtuneFlag = ""
     else:

--- a/setup.py
+++ b/setup.py
@@ -257,17 +257,21 @@ if __name__ == '__main__':
     pypiDescription = f.read()
     f.close()
 
-    # Build for generic (legacy) architectures when enviroment variable
-    # (FASTMAT_GENERIC) is defined
-    if 'FASTMAT_GENERIC' in os.environ:
-        marchFlag = '-march=x86-64'
-        mtuneFlag = '-mtune=core2'
-        WARNING("Building package for generic architectures")
+    # Build for Apple Silicon
+    if platform.system() == "Darwin" and platform.machine() == "arm64": 
+        marchFlag = "-mcpu=apple-m1"
+        mtuneFlag = ""
     else:
-        marchFlag = '-march=native'
-        mtuneFlag = '-mtune=native'
-
-    # define different compiler arguments for each platform
+        # Build for generic (legacy) architectures when enviroment variable
+        # (FASTMAT_GENERIC) is defined
+        if 'FASTMAT_GENERIC' in os.environ:
+            marchFlag = '-march=x86-64'
+            mtuneFlag = '-mtune=core2'
+            WARNING("Building package for generic architectures")
+        else:
+            marchFlag = '-march=native'
+            mtuneFlag = '-mtune=native'
+    # Define different compiler arguments for each platform
     strPlatform = platform.system()
     compilerArguments = []
     linkerArguments = []


### PR DESCRIPTION
The -march and -mtune compiler options do not work with Apple clang on Apple Silicon Arm machines. Instead, the -mcpu compiler option should be used. The setup.py script now distinguishes between x86 and Apple-Silicon Arm and chooses the right compiler options.