### PR TITLE
Adjusted setup.py to handle Apple ARM chips

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,13 +263,16 @@ if __name__ == '__main__':
     if 'FASTMAT_GENERIC' in os.environ:
         marchFlag = '-march=x86-64'
         mtuneFlag = '-mtune=core2'
+        mcpuFlag = '-mcpu=arm'
         WARNING("Building package for generic architectures")
     else:
         marchFlag = '-march=native'
         mtuneFlag = '-mtune=native'
+        mcpuFlag = '-mcpu=native'
 
     # define different compiler arguments for each platform
     strPlatform = platform.system()
+    strMachine = platform.machine()
     compilerArguments = []
     linkerArguments = []
     useGccOverride = False
@@ -281,8 +284,12 @@ if __name__ == '__main__':
         compilerArguments += ['-Ofast', marchFlag, mtuneFlag]
         useGccOverride = True
     elif strPlatform == 'Darwin':
-        # assuming Darwin
-        compilerArguments += ['-Ofast', marchFlag, mtuneFlag]
+        if strMachine == "arm64":
+            # assuming Darwin ARM
+            compilerArguments += ['-Ofast', mcpuFlag]
+        else:
+            # assuming Darwin x86
+            compilerArguments += ['-Ofast', marchFlag, mtuneFlag]
     else:
         WARNING("Your platform is currently not supported by %s: %s" % (
             packageName, strPlatform))


### PR DESCRIPTION
The Apple clang compiler on systems with Apple ARM chips (e.g. M1 and M2) does not support the '-march' and '-mtune' compiler arguments anymore. The newer compiler argument '-mcpu' should be used. According to https://maskray.me/blog/2022-08-28-march-mcpu-mtune it is an alternative to both '-march' and '-mtune'. The setup.py script distinguishes now between Apple (Darwin) x86 and ARM64 systems and uses '-mcpu' as 'native' or 'arm', depending wether FASTMAT_GENERIC is set or not. With this configuration, no extra environment variable should be needed.